### PR TITLE
Disabled tracer using too much memory

### DIFF
--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -519,8 +519,8 @@ class Tracer(object):
                 span.set_tag('a', 'b')
         """
         if self.enabled is False:
-            def noop(ob):
-                return ob
+            def noop(f):
+                return f
             return noop
 
         def wrap_decorator(f):

--- a/ddtrace/tracer.py
+++ b/ddtrace/tracer.py
@@ -397,6 +397,9 @@ class Tracer(object):
             parent2 = tracer.trace('parent2')   # has no parent span
             parent2.finish()
         """
+        if self.enabled is False:
+            return
+
         # retrieve the Context using the context provider and create
         # a new Span that could be a root or a nested span
         context = self.get_call_context()
@@ -515,6 +518,11 @@ class Tracer(object):
                 span = tracer.current_span()
                 span.set_tag('a', 'b')
         """
+        if self.enabled is False:
+            def noop(ob):
+                return ob
+            return noop
+
         def wrap_decorator(f):
             # FIXME[matt] include the class name for methods.
             span_name = name if name else '%s.%s' % (f.__module__, f.__name__)


### PR DESCRIPTION
We're seeing for environments where the tracer is disabled, the memory used by ddtrace is non-negligible for larger jobs.

We're testing to see if this change is enough to stop it from using the additional memory and to see what tests fail with these changes.